### PR TITLE
chore: Update FUNDING link

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://donate.keyman.com/
+custom: https://donate.givedirect.org/?cid=13536&desig=Keyman


### PR DESCRIPTION
The donate.keyman.com site was shuttered, so this updates the FUNDING.yml file (displayed on main repo page)

![image](https://user-images.githubusercontent.com/7358010/231623473-7da40fdf-050d-4671-806a-93a15069715a.png)

afaict, the query params `cid` and `desig` are needed, and `n` gets generated...


